### PR TITLE
add empty output folder to avoid runtempty ime errors of Opc.Ua.Model…

### DIFF
--- a/FooFltModel/.gitignore
+++ b/FooFltModel/.gitignore
@@ -1,0 +1,4 @@
+# This folder will hold the output files of Opc.Ua.ModelCompiler.exe
+# ignore evertything in this folder except for this file itself
+*
+!.gitignore


### PR DESCRIPTION
This PR will fix the error message
`Could not find a part of the path 'C:\opcua-modeling-tutorial\FooFltModel\FooFlt.Classes.cs'.`
of `Opc.Ua.ModelCompiler.exe` by adding an empty folder `FooFltModel` to this repo.